### PR TITLE
Add uaccess tag to udev rule for user access

### DIFF
--- a/install/udev.rules
+++ b/install/udev.rules
@@ -1,4 +1,4 @@
 # Make dongles and uinput accessible to all users
-SUBSYSTEM=="usb", ATTRS{idVendor}=="045e", ATTRS{idProduct}=="02e6", MODE="0666"
-SUBSYSTEM=="usb", ATTRS{idVendor}=="045e", ATTRS{idProduct}=="02fe", MODE="0666"
+SUBSYSTEM=="usb", ATTRS{idVendor}=="045e", ATTRS{idProduct}=="02e6", MODE="0666" TAG+="uaccess"
+SUBSYSTEM=="usb", ATTRS{idVendor}=="045e", ATTRS{idProduct}=="02fe", MODE="0666" TAG+="uaccess"
 KERNEL=="uinput", SUBSYSTEM=="misc", MODE="0666"


### PR DESCRIPTION
Patch from Debian, based off on lintian:
https://lintian.debian.org/tags/udev-rule-missing-uaccess.html
and Gadget setup wiki:
https://wiki.debian.org/USB/GadgetSetup

Note that I didn't spot any malfunction without this on my system, I'm just following the advice from lintian.