### PR TITLE
Change service type to idle to delay start

### DIFF
--- a/install/service.in
+++ b/install/service.in
@@ -4,6 +4,7 @@ Description=Xbox One Wireless Dongle Driver
 [Service]
 ExecStart=#BINDIR#/xow
 DynamicUser=true
+Type=idle
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
My system boots so fast, that the dongle device won't be ready when the xow service wants to start. Which ends in a failure:

```
Mär 08 20:27:01 NoXP-PC systemd[1]: Started Xbox One Wireless Dongle Driver.
Mär 08 20:27:01 NoXP-PC xow[1035]: 2020-03-08 20:27:01 INFO  - xow v0.3-24-gc8a1554 ©Severin v. W.
Mär 08 20:27:01 NoXP-PC xow[1035]: 2020-03-08 20:27:01 ERROR - Error opening device: LIBUSB_ERROR_ACCESS
Mär 08 20:27:01 NoXP-PC systemd[1]: xow.service: Main process exited, code=exited, status=1/FAILURE
Mär 08 20:27:01 NoXP-PC systemd[1]: xow.service: Failed with result 'exit-code'.
```

Setting the service [Type to idle](https://www.freedesktop.org/software/systemd/man/systemd.service.html) takes care the service will be delayed and can start properly:

> Behavior of idle is very similar to simple; however, actual execution of the service program is delayed until all active jobs are dispatched. This may be used to avoid interleaving of output of shell services with the status output on the console. Note that this type is useful only to improve console output, it is not useful as a general unit ordering tool, and the effect of this service type is subject to a 5s timeout, after which the service program is invoked anyway.
