### PR TITLE
Use udev to trigger xow service when dongle is plugged in

### DIFF
--- a/install/service.in
+++ b/install/service.in
@@ -6,7 +6,7 @@ After=dev-xow.device
 [Service]
 Type=simple
 ExecStart=#BINDIR#/xow
-Restart=on-failure
+Restart=on-success
 
 [Install]
 WantedBy=default.target

--- a/install/service.in
+++ b/install/service.in
@@ -1,10 +1,12 @@
 [Unit]
 Description=Xbox One Wireless Driver
+BindsTo=dev-xow.device
+After=dev-xow.device
 
 [Service]
-Type=idle
+Type=simple
 ExecStart=#BINDIR#/xow
-Restart=on-success
+Restart=on-failure
 
 [Install]
 WantedBy=default.target

--- a/install/udev.rules
+++ b/install/udev.rules
@@ -1,4 +1,4 @@
 # Make dongles and uinput accessible to all users
-SUBSYSTEM=="usb", ATTRS{idVendor}=="045e", ATTRS{idProduct}=="02e6", MODE="0666"
-SUBSYSTEM=="usb", ATTRS{idVendor}=="045e", ATTRS{idProduct}=="02fe", MODE="0666"
+SUBSYSTEM=="usb", ATTRS{idVendor}=="045e", ATTRS{idProduct}=="02e6", MODE="0666", SYMLINK+="xow", TAG+="systemd", ENV{SYSTEMD_USER_WANTS}="xow.service"
+SUBSYSTEM=="usb", ATTRS{idVendor}=="045e", ATTRS{idProduct}=="02fe", MODE="0666", SYMLINK+="xow", TAG+="systemd", ENV{SYSTEMD_USER_WANTS}="xow.service"
 KERNEL=="uinput", SUBSYSTEM=="misc", MODE="0666"

--- a/install/udev.rules
+++ b/install/udev.rules
@@ -1,4 +1,6 @@
 # Make dongles and uinput accessible to all users
-SUBSYSTEM=="usb", ATTRS{idVendor}=="045e", ATTRS{idProduct}=="02e6", MODE="0666", SYMLINK+="xow", TAG+="systemd", ENV{SYSTEMD_USER_WANTS}="xow.service"
-SUBSYSTEM=="usb", ATTRS{idVendor}=="045e", ATTRS{idProduct}=="02fe", MODE="0666", SYMLINK+="xow", TAG+="systemd", ENV{SYSTEMD_USER_WANTS}="xow.service"
+ACTION!="remove", SUBSYSTEM=="usb", ATTRS{idVendor}=="045e", ATTRS{idProduct}=="02e6", MODE="0666", SYMLINK+="xow", TAG+="systemd", ENV{SYSTEMD_USER_WANTS}="xow.service"
+ACTION!="remove", SUBSYSTEM=="usb", ATTRS{idVendor}=="045e", ATTRS{idProduct}=="02fe", MODE="0666", SYMLINK+="xow", TAG+="systemd", ENV{SYSTEMD_USER_WANTS}="xow.service"
+ACTION=="remove", SUBSYSTEM=="usb", ENV{Product}="45e/2e6/*", TAG+="systemd"
+ACTION=="remove", SUBSYSTEM=="usb", ENV{Product}="45e/2fe/*", TAG+="systemd"
 KERNEL=="uinput", SUBSYSTEM=="misc", MODE="0666"


### PR DESCRIPTION
Hi there, I'm in the process of making a package for my distro (Solus).
Someone pointed me to the idea that the service could be activated only when the dongle is inserted.

I investigated some time into udev and systemd and found a solution.

I made the changes in the audio branch, because of the user service change.

With these changes udev automatically triggers the xow user service to start, when the usb is plugged in. The service is automatically stopped when unplugged.

This is a bit more user friendly in my opinion, as the user doesn't need to know anything about systemd services.