### PR TITLE
Create basic OpenRC service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 internal/*
 firmware.bin
-xow
+/xow
 *.d
 *.o
 .vscode/*

--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,7 @@ firmware.bin:
 .PHONY: install
 install: xow
 	sed 's|#BINDIR#|$(BINDIR)|' install/service.in > xow.service
+	sed 's|#BINDIR#|$(BINDIR)|' install/openrc/initd/xow.in > install/openrc/initd/xow
 	install -D -m 755 xow $(DESTDIR)$(BINDIR)/xow
 	install -D -m 644 install/udev.rules $(DESTDIR)$(UDEVDIR)/50-xow.rules
 	install -D -m 644 install/modules.conf $(DESTDIR)$(MODLDIR)/xow-uinput.conf

--- a/install/openrc/confd/xow
+++ b/install/openrc/confd/xow
@@ -1,0 +1,6 @@
+# Enable compatibility mode (Xbox 360 emulation)
+#XOW_COMPATIBILITY=1
+
+# Defaults to nobody if not set
+XOW_USER=
+XOW_GROUP=

--- a/install/openrc/initd/xow.in
+++ b/install/openrc/initd/xow.in
@@ -1,0 +1,27 @@
+#!/sbin/openrc-run
+
+description="Xbox One Wireless Dongle Driver"
+command="#BINDIR#/xow"
+
+command_user="${XOW_USER:-nobody}:${XOW_GROUP:-nobody}"
+supervisor="supervise-daemon"
+output_log="/var/log/${RC_SVCNAME}.log"
+error_log="${output_log}"
+
+extra_started_commands="pair"
+description_pair="Enable dongle pairing mode"
+
+depend() {
+    keyword -lxc -openvz -docker
+}
+
+start_pre() {
+    checkpath -q \
+        --owner "${command_user}" \
+        --file "${output_log}"
+}
+
+pair() {
+    "${supervisor}" "${RC_SVCNAME}" \
+        --signal USR1
+}


### PR DESCRIPTION
Support is optional, therefore init/conf files will be prepared
for packagers while building but not installed.

Closes #102