### PR TITLE
Fix compatibility with older versions of libusb

### DIFF
--- a/dongle/usb.cpp
+++ b/dongle/usb.cpp
@@ -131,12 +131,13 @@ int UsbDevice::bulkRead(
 
 bool UsbDevice::bulkWrite(uint8_t endpoint, Bytes &data)
 {
+    int transferred = 0;
     int error = libusb_bulk_transfer(
         handle,
         endpoint | LIBUSB_ENDPOINT_OUT,
         data.raw(),
         data.size(),
-        nullptr,
+        &transferred,
         USB_TIMEOUT_WRITE
     );
 


### PR DESCRIPTION
Older versions of libusb (ie. 1.0.20) have a bug in do_sync_bulk_transfer where it assumes you are passing in a valid pointer for the transferred data length:

`*transferred = transfer->actual_length;
`

Newer versions of libusb make sure the pointer is not null:
```
if (transferred)
                *transferred = transfer->actual_length;
```

However, xow passes nullptr for this method causing it to fail.  The fix is to simply create a variable and pass it to the method even though it's not used.

This fixes issue #125.