### PR TITLE
Add support for the Surface Book 2's built-in dongle

### DIFF
--- a/dongle/dongle.h
+++ b/dongle/dongle.h
@@ -34,6 +34,9 @@
 #define DONGLE_PID_OLD 0x02e6
 #define DONGLE_PID_NEW 0x02fe
 
+// Product ID for Microsoft Surface Book 2 built-in dongle
+#define DONGLE_PID_SURFACE 0x091e
+
 /*
  * Handles received 802.11 packets
  * Delegates GIP (Game Input Protocol) packets to controllers

--- a/install/udev.rules
+++ b/install/udev.rules
@@ -1,4 +1,5 @@
 # Make dongles and uinput accessible to all users
 SUBSYSTEM=="usb", ATTRS{idVendor}=="045e", ATTRS{idProduct}=="02e6", MODE:="0666"
 SUBSYSTEM=="usb", ATTRS{idVendor}=="045e", ATTRS{idProduct}=="02fe", MODE:="0666"
+SUBSYSTEM=="usb", ATTRS{idVendor}=="045e", ATTRS{idProduct}=="091e", MODE:="0666"
 KERNEL=="uinput", SUBSYSTEM=="misc", MODE:="0666"

--- a/xow.cpp
+++ b/xow.cpp
@@ -63,7 +63,8 @@ int main()
     );
     std::unique_ptr<UsbDevice> device = manager.getDevice({
         { DONGLE_VID, DONGLE_PID_OLD },
-        { DONGLE_VID, DONGLE_PID_NEW }
+        { DONGLE_VID, DONGLE_PID_NEW },
+        { DONGLE_VID, DONGLE_PID_SURFACE }
     }, terminate);
 
     // Block signals and pass them to the signalfd


### PR DESCRIPTION
add the product ID for surface book 2's built-in xbox dongle