### PR TITLE
Track libusb v1.0.23 and statically link to it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,9 +5,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Install prerequisites
-      run: sudo apt update && sudo apt install curl cabextract libusb-1.0-0-dev
+      run: sudo apt update && sudo apt install curl cabextract libudev-dev
     - name: Checkout
       uses: actions/checkout@v2
+      with:
+        submodules: true
     - name: Make (debug)
       run: make clean && make BUILD=DEBUG
     - name: Make (release)

--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@ firmware.bin
 xow
 *.d
 *.o
+*.a
 .vscode/*

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "external/libusb"]
+	path = external/libusb
+	url = https://github.com/libusb/libusb
+	branch = refs/tags/v1.0.23

--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,15 @@
 BUILD := DEBUG
 VERSION := $(shell git describe --tags)
 
-FLAGS := -Wall -Wpedantic -std=c++11 -MMD -MP
+FLAGS := -Wall -Wpedantic -std=c++11 -MMD -MP -Iexternal/headers
 DEBUG_FLAGS := -Og -g -DDEBUG
 RELEASE_FLAGS := -O3
 DEFINES := -DVERSION=\"$(VERSION)\"
 
 CXXFLAGS += $(FLAGS) $($(BUILD)_FLAGS) $(DEFINES)
-LDLIBS += -lpthread -lusb-1.0
+LDLIBS += -lpthread -ludev
 SOURCES := $(wildcard *.cpp) $(wildcard */*.cpp)
-OBJECTS := $(SOURCES:.cpp=.o) firmware.o
+OBJECTS := $(SOURCES:.cpp=.o) firmware.o libusb-1.0.a
 DEPENDENCIES := $(SOURCES:.cpp=.d)
 
 DRIVER_URL := http://download.windowsupdate.com/c/msdownload/update/driver/drvs/2017/07/1cd6a87c-623f-4407-a52d-c31be49e925c_e19f60808bdcbfbd3c3df6be3e71ffc52e43261e.cab
@@ -33,6 +33,11 @@ xow: $(OBJECTS)
 
 firmware.o: firmware.bin
 	$(LD) -r -b binary -z noexecstack -o $@ $<
+
+libusb-1.0.a:
+	cd external/libusb && ./autogen.sh
+	make -C external/libusb
+	cp external/libusb/libusb/.libs/libusb-1.0.a .
 
 firmware.bin:
 	curl -o driver.cab $(DRIVER_URL)

--- a/external/headers/libusb-1.0
+++ b/external/headers/libusb-1.0
@@ -1,0 +1,1 @@
+../../external/libusb/libusb/


### PR DESCRIPTION
Works around #141  
God knows when 1.0.25 will come out.
Fedora maintainer won't pull the fixing patch to 1.0.24 due to the large footprint of it.
So here it is.