### PR TITLE
implement memory for 10 rumble effects

### DIFF
--- a/controller/controller.cpp
+++ b/controller/controller.cpp
@@ -281,6 +281,7 @@ void Controller::inputFeedbackReceived(
     // Ignore other types of force feedback
     if (effect.type != FF_RUMBLE)
     {
+        Log::debug("Unknown effect %d", (int)effect.type);
         return;
     }
 

--- a/controller/input.cpp
+++ b/controller/input.cpp
@@ -23,12 +23,16 @@
 #include <unistd.h>
 #include <fcntl.h>
 
-#define INPUT_MAX_FF_EFFECTS 1
-
 InputDevice::InputDevice(
     FeedbackReceived feedbackReceived
 ) : feedbackReceived(feedbackReceived)
 {
+    for(int i=0;i<INPUT_MAX_FF_EFFECTS;i++)
+    {
+        effects[i] = {};
+    }
+
+
     file = open("/dev/uinput", O_RDWR | O_NONBLOCK);
 
     if (file < 0)
@@ -153,6 +157,8 @@ void InputDevice::handleFeedbackUpload(uint32_t id)
 
     upload.request_id = id;
 
+    Log::debug("Got feedback upload %d", id);
+
     if (ioctl(file, UI_BEGIN_FF_UPLOAD, &upload) < 0)
     {
         Log::error(
@@ -163,7 +169,7 @@ void InputDevice::handleFeedbackUpload(uint32_t id)
         return;
     }
 
-    effect = upload.effect;
+    effects[upload.effect.id] = upload.effect; //should really check the id first but the driver always seems to assign the first available from 0.
     upload.retval = 0;
 
     if (ioctl(file, UI_END_FF_UPLOAD, &upload) < 0)
@@ -173,6 +179,8 @@ void InputDevice::handleFeedbackUpload(uint32_t id)
             strerror(errno)
         );
     }
+
+    Log::debug("Uploaded effect id %d", upload.effect.id);
 }
 
 void InputDevice::handleFeedbackErase(uint32_t id)
@@ -180,6 +188,8 @@ void InputDevice::handleFeedbackErase(uint32_t id)
     uinput_ff_erase erase = {};
 
     erase.request_id = id;
+
+    Log::debug("Got feedback erase %d", id);
 
     if (ioctl(file, UI_BEGIN_FF_ERASE, &erase) < 0)
     {
@@ -191,7 +201,7 @@ void InputDevice::handleFeedbackErase(uint32_t id)
         return;
     }
 
-    effect = {};
+    effects[erase.effect_id] = {};
     erase.retval = 0;
 
     if (ioctl(file, UI_END_FF_ERASE, &erase) < 0)
@@ -201,15 +211,18 @@ void InputDevice::handleFeedbackErase(uint32_t id)
             strerror(errno)
         );
     }
+
+    Log::debug("Erased effect id %d", erase.effect_id);
 }
 
 void InputDevice::handleEvent(input_event event)
 {
+    Log::debug("input_event type %d code %d value %d", (int)event.type, (int)event.code, (int)event.value); 
     if (event.type == EV_UINPUT)
-    {
+    {//special event type, see uinput.h
         if (event.code == UI_FF_UPLOAD)
         {
-            handleFeedbackUpload(event.value);
+            handleFeedbackUpload(event.value); //value is the uinput event id, not to be confused with the request id
         }
 
         else if (event.code == UI_FF_ERASE)
@@ -223,12 +236,18 @@ void InputDevice::handleEvent(input_event event)
         if (event.code == FF_GAIN)
         {
             // Gain varies between 0 and 0xffff
-            effectGain = event.value;
+            effectGain = event.value; //seems to be device-wide, not tied to any effect
+            Log::debug("Gain adjusted to %d", (int)effectGain);
         }
 
-        else if (event.code == effect.id)
+        else if (event.code >= 0 && event.code < INPUT_MAX_FF_EFFECTS) //should really check if the effect has been erased or not
         {
-            feedbackReceived(effectGain, effect, event.value);
+            Log::debug("Triggering effect %d", (int)event.code);
+            feedbackReceived(effectGain, effects[event.code], event.value);
+        }
+        else
+        {
+            Log::debug("Event code %d not handled", (int)event.code);
         }
     }
 }

--- a/controller/input.h
+++ b/controller/input.h
@@ -27,6 +27,8 @@
 #include <stdexcept>
 #include <linux/uinput.h>
 
+#define INPUT_MAX_FF_EFFECTS 10
+
 /*
  * User mode input device for gamepads
  * Passes force feedback events to callback
@@ -91,7 +93,7 @@ private:
     InterruptibleReader eventReader;
     std::thread eventThread;
 
-    ff_effect effect = {};
+    ff_effect effects[INPUT_MAX_FF_EFFECTS] = {};
     uint16_t effectGain = 0xffff;
     FeedbackReceived feedbackReceived;
 };


### PR DESCRIPTION
Proton/wine and possibly other applications seem to create a dummy rumble effect when a game starts, and another effect later when actually trying to trigger the rumble. A memory of 1 means only the dummy effect can be created, so you don't get any rumble. Chromium browsers can also grab the effect slot if open, preventing anything else from using it.

This patch adds an array for an arbitrary 10 effects, which should cover every sane application. I've only tried one game with proton, fftest (though the 'weak' rumble was stronger than the 'strong' one...?) and a gamepad viewer with Chromium, but it seems to work as expected.

This should resolve #187 and possibly others.

Feel free to delete the comments and debug messages.