### PR TITLE
Make deprecation notice more clear

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,10 +21,21 @@
   <img src="assets/screenshot.png" alt="Screenshot">
 </p>
 
-# The future of this project
+# This Project is in Maintenance Mode
 
 I realize there have not been any substantial changes to xow in over a year now. This is partly due to the lack of free time for me as a university student. I thought about the numerous feature requests and long-standing bugs and finally decided to abandon the concept of a user mode driver. While it certainly proved a point it also demonstrated how quickly you reach the boundaries of integration with other parts of the operating system (audio, battery reporting, etc.).
-I have been working on a new kernel driver for the last couple of months and it already works pretty well. It is currently USB-only and support for the wireless dongle will be added later on. It has **audio functionality**, **battery reporting** and support for the **chatpad**. **If you would like to give it a try you can head over to the [Discord server](https://discord.gg/FDQxwWk). Feedback is much appreciated!**
+
+As a result of these limitations, I have created a new kernel driver called `xone` that has more features and better stability.
+
+### It is highly recommended to switch from `xow` to [xone](https://github.com/medusalix/xone)
+
+Switching to `xone` will mean that you have
+
+- long-term support & bug fixes
+- better support for Xbox Wireless Dongle
+- support for wireless headsets
+- improved performance
+- better quality of life features (audio, battery reporting, etc.)
 
 ## About
 


### PR DESCRIPTION
### Purpose
While trying to figure out how to use my wireless headset and Xbox Dongle, I found it was pretty difficult to figure out which one of the three drivers to use

### Changes
This PR reformats the deprecation notice to hopefully be a bit more clear regarding the status of this project, and that people should use `xone` instead

(related to https://github.com/medusalix/xone/pull/4)